### PR TITLE
Potential fix for code scanning alert no. 16: Writable file handle closed without error handling

### DIFF
--- a/os/osutil/write.go
+++ b/os/osutil/write.go
@@ -76,12 +76,16 @@ func (fw *FileWriter) Close() error {
 	return fw.File.Close()
 }
 
-func WriteFileReader(filename string, r io.Reader, perm os.FileMode) error {
+func WriteFileReader(filename string, r io.Reader, perm os.FileMode) (err error) {
 	f, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	_, err = io.Copy(f, r)
 	return err


### PR DESCRIPTION
Potential fix for [https://github.com/grokify/mogo/security/code-scanning/16](https://github.com/grokify/mogo/security/code-scanning/16)

In general, to fix this class of problem you must always check and handle the error returned by `(*os.File).Close` when working with writable file descriptors. When using `defer`, this usually means turning `defer f.Close()` into a deferred function that captures and possibly combines the `Close` error with any existing error you plan to return.

For `WriteFileReader` specifically, the best fix without changing its external behavior is to introduce a named return value for the error and replace the bare `defer f.Close()` with a deferred function that calls `f.Close()` and, if `WriteFileReader` has not already recorded an error, assigns any `Close` error to the return variable. We keep returning the `io.Copy` error when it occurs, but if `io.Copy` succeeds and `Close` fails, we now return the `Close` error instead of `nil`. This requires:
- Changing the function signature to `func WriteFileReader(...) (err error)`.
- Rewriting the `defer f.Close()` into a deferred closure that checks and records `Close`’s error.
- Ensuring we assign `err` from `io.Copy` to the named return, and finally `return` without arguments so the named error is returned.

All changes are confined to `WriteFileReader` in `os/osutil/write.go`; no new imports or helper functions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
