### PR TITLE
feat(osutil): add ValidatePathComponent, JoinSecure, FindFirstExistingSecure

### DIFF
--- a/os/osutil/filepath.go
+++ b/os/osutil/filepath.go
@@ -50,6 +50,87 @@ func AbsPathSecure(path string) (string, error) {
 	return AbsFilepath(path)
 }
 
+// ErrInvalidPathComponent is returned when a value contains characters
+// unsafe to use as a single filesystem path component.
+var ErrInvalidPathComponent = errors.New("value is not a valid path component")
+
+// ErrPathEscapesRoot is returned when a joined path resolves outside the
+// root directory it was joined against.
+var ErrPathEscapesRoot = errors.New("path escapes root directory")
+
+// pathComponentPattern allowlists characters safe to use as a single path
+// component: ASCII letters, digits, underscore, and hyphen. It rejects path
+// separators, ".", "..", and any other character that could let a
+// caller-supplied value escape its intended directory when joined into a
+// path — the allowlist form recommended for exactly this purpose (see the
+// path-injection guidance referenced in ValidateNoTraversal above).
+var pathComponentPattern = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// ValidatePathComponent checks that component is safe to use as a single
+// filesystem path element: non-empty, containing only ASCII letters,
+// digits, underscore, and hyphen. Use this at the boundary — right after
+// reading a value from a request, URL param, or query string — to reject
+// malformed input early, before it reaches any path construction. Returns
+// ErrInvalidPathComponent if component fails the check.
+//
+// This is deliberately stricter than ValidateNoTraversal (which only
+// rejects ".."): a component is expected to be a single filename-like
+// value, not an arbitrary relative path, so it can't contain "/" or "\"
+// either.
+func ValidatePathComponent(component string) error {
+	if !pathComponentPattern.MatchString(component) {
+		return fmt.Errorf("%w: %s", ErrInvalidPathComponent, component)
+	}
+	return nil
+}
+
+// JoinSecure joins root with elem and confirms the result — resolved
+// relative to root via filepath.Rel — does not escape root. It rejects
+// results that are absolute relative to root, or that require crossing
+// above it (any ".." component surviving Clean), returning
+// ErrPathEscapesRoot in either case.
+//
+// Call this immediately before the joined path is used in a filesystem
+// operation; it's what actually closes off path traversal regardless of
+// what elem contains. ValidatePathComponent at the request boundary is
+// defense in depth, not a substitute — elem may legitimately be a
+// multi-segment relative path (e.g. "source/prd.md"), which
+// ValidatePathComponent would reject.
+func JoinSecure(root string, elem ...string) (string, error) {
+	candidate := filepath.Join(append([]string{root}, elem...)...)
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q relative to %q: %w", candidate, root, err)
+	}
+	if filepath.IsAbs(rel) || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("%w: %q", ErrPathEscapesRoot, candidate)
+	}
+	return candidate, nil
+}
+
+// FindFirstExistingSecure tries each of root+relCandidates (each validated
+// with JoinSecure) in order and returns the path and contents of the first
+// one that exists and can be read. Candidates that fail JoinSecure are
+// skipped, not treated as an error. Returns os.ErrNotExist if none of the
+// candidates exist.
+//
+// This is a convenience for the common "try several filename patterns for
+// an ID" lookup — e.g. trying both "<id>.json" and "<id>.<type>.json" — so
+// callers don't have to interleave JoinSecure calls with the existence
+// check themselves.
+func FindFirstExistingSecure(root string, relCandidates ...string) (path string, data []byte, err error) {
+	for _, rel := range relCandidates {
+		p, joinErr := JoinSecure(root, rel)
+		if joinErr != nil {
+			continue
+		}
+		if b, readErr := os.ReadFile(p); readErr == nil {
+			return p, b, nil
+		}
+	}
+	return "", nil, os.ErrNotExist
+}
+
 func IsDir(name string) (bool, error) {
 	if fi, err := os.Stat(name); err != nil {
 		return false, err

--- a/os/osutil/filepath_test.go
+++ b/os/osutil/filepath_test.go
@@ -1,6 +1,7 @@
 package osutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -174,6 +175,141 @@ func TestSanitizePath(t *testing.T) {
 		}
 		if result != testDir {
 			t.Errorf("SanitizePath() = %q, want %q", result, testDir)
+		}
+	})
+}
+
+func TestValidatePathComponent(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		wantErr   bool
+	}{
+		{"valid alphanumeric", "abc123", false},
+		{"valid with hyphen", "INIT-VISIONSTUDIO-001", false},
+		{"valid with underscore", "period_2026_W30", false},
+		{"empty", "", true},
+		{"dot", ".", true},
+		{"dot-dot", "..", true},
+		{"path traversal", "../../etc/passwd", true},
+		{"forward slash", "foo/bar", true},
+		{"backslash", "foo\\bar", true},
+		{"leading traversal no separator", "..secret", true},
+		{"space", "foo bar", true},
+		{"null byte", "foo\x00bar", true},
+		{"unicode lookalike slash", "foo∕bar", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePathComponent(tt.component)
+			if tt.wantErr && err == nil {
+				t.Errorf("ValidatePathComponent(%q) = nil, want error", tt.component)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("ValidatePathComponent(%q) = %v, want nil", tt.component, err)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrInvalidPathComponent) {
+				t.Errorf("ValidatePathComponent(%q) error = %v, want wrapped ErrInvalidPathComponent", tt.component, err)
+			}
+		})
+	}
+}
+
+func TestJoinSecure(t *testing.T) {
+	root := filepath.FromSlash("/a/b")
+	tests := []struct {
+		name    string
+		root    string
+		elem    []string
+		want    string
+		wantErr bool
+	}{
+		{"direct child", root, []string{"c"}, filepath.FromSlash("/a/b/c"), false},
+		{"nested child", root, []string{"c", "d.md"}, filepath.FromSlash("/a/b/c/d.md"), false},
+		{"id plus suffix", root, []string{"myid.json"}, filepath.FromSlash("/a/b/myid.json"), false},
+		{"escapes via ..", root, []string{"../../etc/passwd"}, "", true},
+		{"escapes via embedded ..", root, []string{"c/../../etc/passwd"}, "", true},
+		{"sibling that shares a prefix", root, []string{"../bc"}, "", true},
+		// filepath.Join treats every element as a segment to clean, not an
+		// override — an absolute-looking elem still lands under root.
+		{"absolute-looking element still joins under root", root, []string{"/etc/passwd"}, filepath.FromSlash("/a/b/etc/passwd"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := JoinSecure(tt.root, tt.elem...)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("JoinSecure(%q, %v) = %q, nil; want error", tt.root, tt.elem, got)
+				}
+				if !errors.Is(err, ErrPathEscapesRoot) {
+					t.Errorf("JoinSecure(%q, %v) error = %v, want wrapped ErrPathEscapesRoot", tt.root, tt.elem, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("JoinSecure(%q, %v) unexpected error: %v", tt.root, tt.elem, err)
+			}
+			if got != tt.want {
+				t.Errorf("JoinSecure(%q, %v) = %q, want %q", tt.root, tt.elem, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("exact root with no elem", func(t *testing.T) {
+		dir := t.TempDir()
+		got, err := JoinSecure(dir)
+		if err != nil {
+			t.Fatalf("JoinSecure(root) unexpected error: %v", err)
+		}
+		if filepath.Clean(got) != filepath.Clean(dir) {
+			t.Errorf("JoinSecure(root) = %q, want %q", got, dir)
+		}
+	})
+}
+
+func TestFindFirstExistingSecure(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "real.json"), []byte(`{"ok":true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("finds the first existing candidate", func(t *testing.T) {
+		path, data, err := FindFirstExistingSecure(dir, "missing.json", "real.json", "also-missing.json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if filepath.Base(path) != "real.json" {
+			t.Errorf("path = %q, want basename real.json", path)
+		}
+		if string(data) != `{"ok":true}` {
+			t.Errorf("data = %q, want %q", data, `{"ok":true}`)
+		}
+	})
+
+	t.Run("returns ErrNotExist when nothing matches", func(t *testing.T) {
+		_, _, err := FindFirstExistingSecure(dir, "missing.json", "also-missing.json")
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("err = %v, want os.ErrNotExist", err)
+		}
+	})
+
+	t.Run("skips candidates that escape root instead of erroring", func(t *testing.T) {
+		path, data, err := FindFirstExistingSecure(dir, "../../etc/passwd", "real.json")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if filepath.Base(path) != "real.json" {
+			t.Errorf("path = %q, want basename real.json (traversal candidate should be skipped)", path)
+		}
+		if string(data) != `{"ok":true}` {
+			t.Errorf("data = %q, want %q", data, `{"ok":true}`)
+		}
+	})
+
+	t.Run("never escapes root even if every safe candidate is missing", func(t *testing.T) {
+		_, _, err := FindFirstExistingSecure(dir, "../../etc/passwd")
+		if !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("err = %v, want os.ErrNotExist", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Adds a stronger path-safety layer to `os/osutil` alongside the existing `ValidateNoTraversal`/`CleanPathSecure`/`AbsPathSecure`:

- **`ValidatePathComponent(component string) error`** — allowlists a single path element (letters, digits, `_`, `-`) rather than denylisting only `..`. Closes gaps `ValidateNoTraversal` leaves open (e.g. embedded separators like `foo/bar`).
- **`JoinSecure(root string, elem ...string) (string, error)`** — joins `root`+`elem` and confirms the result doesn't resolve outside `root`, via `filepath.Rel` + `filepath.IsAbs`. This is the exact idiom [CodeQL's `go/path-injection` query](https://codeql.github.com/codeql-query-help/go/go-path-injection/) recognizes as a sanitizer — verified empirically: a `filepath.Clean` + `strings.HasPrefix` containment check wrapped in a helper function did **not** clear a real CodeQL scan in a downstream consumer, but the `filepath.Rel`/`filepath.IsAbs` form did.
- **`FindFirstExistingSecure(root string, relCandidates ...string) (path string, data []byte, err error)`** — wraps the common "try several filename patterns for an ID, return the first that exists" lookup atop `JoinSecure`.

## Motivation

Consolidating ad hoc path-traversal guards duplicated across `ProductBuildersHQ/visionstudio`'s `cmd/daemon` HTTP handlers — each using `ValidateNoTraversal` alone, which CodeQL correctly still flagged (it doesn't stop embedded `/` or validate the final resolved path) — into one well-tested, reusable implementation upstream, rather than a repo-local package.

## Verification

- `go build ./os/osutil/...` ✓
- `go test ./os/osutil/...` ✓ (all pass, including 25 new table-driven cases across the three functions)
- `go vet ./os/osutil/...` ✓
- `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0 ./os/osutil/...` → 0 issues
- `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)